### PR TITLE
fix: temp solution for use-piscem

### DIFF
--- a/utils/simpleaf_workflow_utils.libsonnet
+++ b/utils/simpleaf_workflow_utils.libsonnet
@@ -359,18 +359,118 @@
                                         else
                                             given_o
                                     ,
-                                    // piscem
-                                    local given_piscem = $.get(field, "--use-piscem", use_default=true),
-                                    [
+
+                                    // TODO: abundon this chunk when piscem bug is fixed
+                                    // currently piscem has an bug: it will fail if setting custom kmer length.
+                                    // So, here I check if --kmer-length flag is set. 
+                                    // If it is set, then no piscem. Otherwise, we can call piscem if asked
+                                    // If this bug is fixed, then we can turn to the logics implmented below
+                                    "--use-piscem": 
+                                        // get kmer and minimizer length from workflow 
+                                        local given_kmer_length = $.get(field, "--kmer-length", use_default=true);
+                                        local given_minimizer_length = $.get(field, "--minimizer-length", use_default=true);
+                                    
                                         // if std.objectHas(program_args, "--use-piscem") &&
                                         if program_name == "simpleaf index" &&
                                             ( 
                                                 use_piscem ||
                                                 std.objectHas(field, "--use-piscem")
+                                            ) && 
+                                            (
+                                                given_kmer_length == "31" ||
+                                                given_kmer_length == null
                                             )
                                         then
-                                            "--use-piscem"
-                                    ]: "",
+                                            ""
+                                        else 
+                                            null
+                                    ,
+
+                                    // TODO: abundon this chunk when piscem bug is fixed
+                                    // same as above
+                                    "--overwrite": 
+                                        // get kmer and minimizer length from workflow 
+                                        local given_kmer_length = $.get(field, "--kmer-length", use_default=true);
+                                        local given_minimizer_length = $.get(field, "--minimizer-length", use_default=true);
+                                    
+                                        // if std.objectHas(program_args, "--use-piscem") &&
+                                        if program_name == "simpleaf index" &&
+                                            ( 
+                                                use_piscem ||
+                                                std.objectHas(field, "--use-piscem")
+                                            ) && 
+                                            (
+                                                given_kmer_length == "31" ||
+                                                given_kmer_length == null
+                                            )
+                                        then
+                                            ""
+                                        else 
+                                            null
+
+
+                                    // piscem
+                                    // TODO: switch to this when piscem bug is fixed
+                                    // It is a little bit complicated. 
+                                    // We have to make sure that if we specify a small kmer-length (< 20),
+                                    // we need to make the appropriate change for --minimizer-length
+                                    // [
+                                    //     // get kmer and minimizer length from workflow 
+                                    //     local given_kmer_length = $.get(field, "--kmer-length", use_default=true);
+                                    //     local given_minimizer_length = $.get(field, "--minimizer-length", use_default=true);
+                                    
+                                    //     if std.objectHas(program_args, "--use-piscem") &&
+                                    //     // if program_name == "simpleaf index" &&
+                                    //         ( 
+                                    //             use_piscem ||
+                                    //             std.objectHas(field, "--use-piscem")
+                                    //         ) && 
+                                    //         (
+                                    //             given_kmer_length == "31" ||
+                                    //             given_kmer_length == null
+                                    //         )
+                                    //     then
+                                    //         "--use-piscem"
+                                    // ]: "",
+
+                                    // [
+                                    //     // if std.objectHas(program_args, "--use-piscem") &&
+                                    //     if program_name == "simpleaf index" &&
+                                    //         ( 
+                                    //             use_piscem ||
+                                    //             std.objectHas(field, "--use-piscem")
+                                    //         )
+                                    //     then
+                                    //         "--overwrite"
+                                    // ]: "",
+
+
+                                    // TODO: ask Julio if we have some simple formula to set minimizer length according to kmer length 
+                                    // TODO: uncomment this chunk if the piscem bug is fixed 
+                                    // In piscem, minimizer length must be smaller than kmer length
+                                    // however, salmon doesn't use minimizer, so it doesn't have this restriction
+                                    // As we want to switch between salmon and piscem, when using piscem, we have to manually set minimizer length 
+                                    // if the kmer-length is no larger than the default minimizer length (19).
+                                    // [
+                                    // // get kmer and minimizer length from workflow 
+                                    // local given_kmer_length = $.get(field, "--kmer-length", use_default=true);
+                                    // local given_minimizer_length = $.get(field, "--minimizer-length", use_default=true);
+                                    
+                                    // // set the criteria
+                                    // if program_name == "simpleaf index" &&
+                                    //         ( 
+                                    //             use_piscem ||
+                                    //             std.objectHas(field, "--use-piscem")
+                                    //         )
+                                    //     then
+                                    //         if given_kmer_length != null then
+                                    //             if given_minimizer_length == null then
+                                    //                 // jsonnet allow string comparison
+                                    //                 // this will work if given_kmer_length is a quoted integer
+                                    //                 if std.parseInt(given_kmer_length) < 20 then
+                                    //                     // "--minimizer-length"
+                                    //                     "--use-piscem"
+                                    // ]: "6"
                                 })
                             else
                                 field


### PR DESCRIPTION
Implement a temp solution for allowing piscem and salmon switching in workflows. Will settle it down after coming up with a formula to calculate minimizer length from kmer-length