### PR TITLE
use awk inplace for feature barcoding barcode replacement 

### DIFF
--- a/protocols/10x-feature-barcode-antibody+crispr/10x-feature-barcode-antibody+crispr.jsonnet
+++ b/protocols/10x-feature-barcode-antibody+crispr/10x-feature-barcode-antibody+crispr.jsonnet
@@ -552,7 +552,7 @@ local workflow = {
             "Step": 5,
             "Program Name": "awk",
             "Active": true,
-            "Arguments": ["'FNR==NR {dict[$1]=$2; next} {$1=($1 in dict) ? dict[$1] : $1}1'", "TBD","TBD"],
+            "Arguments": ["-i inplace", "'FNR==NR {dict[$1]=$2; next} {$1=($1 in dict) ? dict[$1] : $1}1'", "inplace=0", "TBD","TBD"],
         },
 
         // This command is used for converting the 
@@ -677,7 +677,7 @@ local activate_ext_calls(workflow, output_path, fb_ref_path) =
 
             "barcode translation"+: {
                 "Arguments": [
-                    "'FNR==NR {dict[$1]=$2; next} {$1=($1 in dict) ? dict[$1] : $1}1'", 
+                    "-i inplace", "'FNR==NR {dict[$1]=$2; next} {$1=($1 in dict) ? dict[$1] : $1}1'", "inplace=0", 
                     bt_file,
                     rna_quant_bc_file,
                     ">",

--- a/protocols/10x-feature-barcode-antibody/10x-feature-barcode-antibody.jsonnet
+++ b/protocols/10x-feature-barcode-antibody/10x-feature-barcode-antibody.jsonnet
@@ -417,7 +417,7 @@ local workflow = {
             "Step": 5,
             "Program Name": "awk",
             "Active": true,
-            "Arguments": ["'FNR==NR {dict[$1]=$2; next} {$1=($1 in dict) ? dict[$1] : $1}1'", "TBD","TBD"],
+            "Arguments": ["-i inplace", "'FNR==NR {dict[$1]=$2; next} {$1=($1 in dict) ? dict[$1] : $1}1'", "inplace=0", "TBD","TBD"],
         },
 
         // This command is used for converting the 
@@ -508,7 +508,7 @@ local activate_ext_calls(workflow, output_path, fb_ref_path) =
 
             "barcode translation"+: {
                 "Arguments": [
-                    "'FNR==NR {dict[$1]=$2; next} {$1=($1 in dict) ? dict[$1] : $1}1'", 
+                    "-i inplace", "'FNR==NR {dict[$1]=$2; next} {$1=($1 in dict) ? dict[$1] : $1}1'", "inplace=0", 
                     bt_file,
                     rna_quant_bc_file,
                     ">",

--- a/protocols/10x-feature-barcode-crispr/10x-feature-barcode-crispr.jsonnet
+++ b/protocols/10x-feature-barcode-crispr/10x-feature-barcode-crispr.jsonnet
@@ -419,7 +419,7 @@ local workflow = {
             "Step": 5,
             "Program Name": "awk",
             "Active": true,
-            "Arguments": ["'FNR==NR {dict[$1]=$2; next} {$1=($1 in dict) ? dict[$1] : $1}1'", "TBD","TBD"],
+            "Arguments": ["-i inplace", "'FNR==NR {dict[$1]=$2; next} {$1=($1 in dict) ? dict[$1] : $1}1'", "inplace=0", "TBD","TBD"],
         },
 
         // This command is used for converting the 
@@ -510,7 +510,7 @@ local activate_ext_calls(workflow, output_path, fb_ref_path) =
 
             "barcode translation"+: {
                 "Arguments": [
-                    "'FNR==NR {dict[$1]=$2; next} {$1=($1 in dict) ? dict[$1] : $1}1'", 
+                    "-i inplace", "'FNR==NR {dict[$1]=$2; next} {$1=($1 in dict) ? dict[$1] : $1}1'", "inplace=0", 
                     bt_file,
                     rna_quant_bc_file,
                     ">",


### PR DESCRIPTION
The cell barcodes used by GEX and feature barcoding are different (https://kb.10xgenomics.com/hc/en-us/articles/360031133451-Why-is-there-a-discrepancy-in-the-3M-february-2018-txt-barcode-whitelist-).

To replace the barcodes, I used an awk command to replace the barcodes in the GEX count matrxi row names (cellular barcodes) with the correct barcodes. However, I did not say `-i inplace` when running awk, so awk will not overwrite the file. Here I did the change. I assume that the workflow is run on a machine with awk > 4.1, which is the version that -i inplace was introduced.