### PR TITLE
Fix broken doc links and self-host barcode translation file

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,15 @@ This repository is a library of published [`simpleaf workflow`](https://simpleaf
 
 Using the power of [Jsonnet](https://jsonnet.org/), each workflow template published here can be converted to a valid workflow description after filling some required information. For details, please check this the [GitHub repository](https://github.com/COMBINE-lab/simpleaf) and [documentation](https://simpleaf.readthedocs.io/en/latest/index.html).
 
+## Prerequisites
+
+On some systems the default open-file limit is too low for piscem indexing.
+Before running any workflow that builds an index, increase the limit in your shell:
+
+```bash
+ulimit -n 2048
+```
+
 ## Usage
 
 One can fetch individual workflows using the [`simpleaf workflow get`](https://simpleaf.readthedocs.io/en/latest/workflow-get.html) command.

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # protocol-estuary
 
-This repository is a library of published [`simpleaf workflow`](https://simpleaf.readthedocs.io/en/latest/workflow-command.html) templates for easing the commonly and frequently used single-cell data processing pipelines using alevin-fry ecosystem of tools. 
+This repository is a library of published [`simpleaf workflow`](https://simpleaf.readthedocs.io/en/latest/workflow.html) templates for easing the commonly and frequently used single-cell data processing pipelines using alevin-fry ecosystem of tools. 
 
-Using the power of [Jsonnet](https://jsonnet.org/), each workflow template published here can be converted to a valid workflow description after filling some required infomration. For details, please check this the [GitHub repository](https://github.com/COMBINE-lab/simpleaf) and [documentation](https://simpleaf.readthedocs.io/en/latest/index.html).
+Using the power of [Jsonnet](https://jsonnet.org/), each workflow template published here can be converted to a valid workflow description after filling some required information. For details, please check this the [GitHub repository](https://github.com/COMBINE-lab/simpleaf) and [documentation](https://simpleaf.readthedocs.io/en/latest/index.html).
 
 ## Usage
 
-One can fetch individual workflows using the [`get-workflow-config`](https://simpleaf.readthedocs.io/en/latest/get-workflow-config-command.html) program of `simpleaf`. 
-To execute a workflow, one can simply fill required information in its template and pass the template to [`simpleaf workflow`](https://simpleaf.readthedocs.io/en/latest/workflow-command.html).
+One can fetch individual workflows using the [`simpleaf workflow get`](https://simpleaf.readthedocs.io/en/latest/workflow-get.html) command.
+To execute a workflow, one can simply fill required information in its template and pass the template to [`simpleaf workflow run`](https://simpleaf.readthedocs.io/en/latest/workflow-run.html).
 
 ## Contribution
 Our dedicated team is actively developing and publishing new workflow templates into this repository. If you would like to share the workflow template you desired, you are more than welcome to make pull requests and tell us how cool your templates are!

--- a/protocols/10x-chromium-3p-v2/10x-chromium-3p-v2-quant.jsonnet
+++ b/protocols/10x-chromium-3p-v2/10x-chromium-3p-v2-quant.jsonnet
@@ -75,6 +75,7 @@ local template = {
 				"--gff3-fomrat" : false,
 				"--threads" : $.meta_info.threads,
 				"--overwrite" : false,
+				"--work-dir" : $.meta_info.output + "/simpleaf_index/workdir",
 				"--kmer-length" :  31,
 				"--minimizer-length" : utils.ml(std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
 				"--decoy-paths" : null, # only if using piscem >= 0.7

--- a/protocols/10x-chromium-3p-v2/10x-chromium-3p-v2-quant.jsonnet
+++ b/protocols/10x-chromium-3p-v2/10x-chromium-3p-v2-quant.jsonnet
@@ -19,9 +19,6 @@ local meta_info = {
 	# number of threads for all commands
 	threads : 16, # change to other integer if needed # This defines `simpleaf index/quant --threads`
 
-	# boolean, true or false
-	use_piscem : false, # or use_piscem: false # This defines `simpleaf index/quant --use-piscem`
-
 	# Output directory.
 	output: output, # or output: "/path/to/output/dir" # this defines `simpleaf index/quant --output`
 };
@@ -77,10 +74,9 @@ local template = {
 				"--keep-duplicates" : false,
 				"--gff3-fomrat" : false,
 				"--threads" : $.meta_info.threads,
-				"--use-piscem" : $.meta_info.use_piscem, 
-				"--overwrite" : $.meta_info.use_piscem,
+				"--overwrite" : false,
 				"--kmer-length" :  31,
-				"--minimizer-length" : utils.ml($.meta_info.use_piscem, std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
+				"--minimizer-length" : utils.ml(std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
 				"--decoy-paths" : null, # only if using piscem >= 0.7
 			},
 
@@ -128,9 +124,7 @@ local template = {
 				"--expected-ori" :  "fw",
 				"--threads" :  $.meta_info.threads,
 				"--chemistry" :  "10xv2",
-				"--use-selective-alignment" : false, # only if using salmon alevin as theunderlying mapper
 				# piscem options
-				"--use-piscem" : $.meta_info.use_piscem,
 				"--struct-constraints" : false,
 				"--ignore-ambig-hits" : false,
 				"--no-poison" : false,

--- a/protocols/10x-chromium-3p-v2/10x-chromium-3p-v2-quant.jsonnet
+++ b/protocols/10x-chromium-3p-v2/10x-chromium-3p-v2-quant.jsonnet
@@ -74,8 +74,8 @@ local template = {
 				"--keep-duplicates" : false,
 				"--gff3-fomrat" : false,
 				"--threads" : $.meta_info.threads,
-				"--overwrite" : false,
-				"--work-dir" : $.meta_info.output + "/simpleaf_index/workdir",
+				"--overwrite" : true,
+				"--work-dir" : null,
 				"--kmer-length" :  31,
 				"--minimizer-length" : utils.ml(std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
 				"--decoy-paths" : null, # only if using piscem >= 0.7

--- a/protocols/10x-chromium-3p-v2/10x-chromium-3p-v2.jsonnet
+++ b/protocols/10x-chromium-3p-v2/10x-chromium-3p-v2.jsonnet
@@ -19,9 +19,6 @@ local meta_info = {
 	# number of threads for all commands
 	threads : 16, # change to other integer if needed # This defines `simpleaf index/quant --threads`
 
-	# boolean, true or false
-	use_piscem : false, # or use_piscem: false # This defines `simpleaf index/quant --use-piscem`
-
 	# Output directory.
 	output: output, # or output: "/path/to/output/dir" # this defines `simpleaf index/quant --output`
 };
@@ -98,10 +95,9 @@ local template = {
 				"--keep-duplicates" : false,
 				"--gff3-fomrat" : false,
 				"--threads" : $.meta_info.threads,
-				"--use-piscem" : $.meta_info.use_piscem, 
-				"--overwrite" : $.meta_info.use_piscem,
+				"--overwrite" : false,
 				"--kmer-length" :  31,
-				"--minimizer-length" : utils.ml($.meta_info.use_piscem, std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
+				"--minimizer-length" : utils.ml(std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
 				"--decoy-paths" : null, # only if using piscem >= 0.7
 			},
 
@@ -149,9 +145,7 @@ local template = {
 				"--expected-ori" :  "fw",
 				"--threads" :  $.meta_info.threads,
 				"--chemistry" :  "10xv2",
-				"--use-selective-alignment" : false, # only if using salmon alevin as theunderlying mapper
 				# piscem options
-				"--use-piscem" : $.meta_info.use_piscem,
 				"--struct-constraints" : false,
 				"--ignore-ambig-hits" : false,
 				"--no-poison" : false,

--- a/protocols/10x-chromium-3p-v2/10x-chromium-3p-v2.jsonnet
+++ b/protocols/10x-chromium-3p-v2/10x-chromium-3p-v2.jsonnet
@@ -96,6 +96,7 @@ local template = {
 				"--gff3-fomrat" : false,
 				"--threads" : $.meta_info.threads,
 				"--overwrite" : false,
+				"--work-dir" : $.meta_info.output + "/simpleaf_index/workdir",
 				"--kmer-length" :  31,
 				"--minimizer-length" : utils.ml(std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
 				"--decoy-paths" : null, # only if using piscem >= 0.7

--- a/protocols/10x-chromium-3p-v2/10x-chromium-3p-v2.jsonnet
+++ b/protocols/10x-chromium-3p-v2/10x-chromium-3p-v2.jsonnet
@@ -95,8 +95,8 @@ local template = {
 				"--keep-duplicates" : false,
 				"--gff3-fomrat" : false,
 				"--threads" : $.meta_info.threads,
-				"--overwrite" : false,
-				"--work-dir" : $.meta_info.output + "/simpleaf_index/workdir",
+				"--overwrite" : true,
+				"--work-dir" : null,
 				"--kmer-length" :  31,
 				"--minimizer-length" : utils.ml(std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
 				"--decoy-paths" : null, # only if using piscem >= 0.7

--- a/protocols/10x-chromium-3p-v3/10x-chromium-3p-v3-quant.jsonnet
+++ b/protocols/10x-chromium-3p-v3/10x-chromium-3p-v3-quant.jsonnet
@@ -75,6 +75,7 @@ local template = {
 				"--gff3-fomrat" : false,
 				"--threads" : $.meta_info.threads,
 				"--overwrite" : false,
+				"--work-dir" : $.meta_info.output + "/simpleaf_index/workdir",
 				"--kmer-length" :  31,
 				"--minimizer-length" : utils.ml(std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
 				"--decoy-paths" : null, # only if using piscem >= 0.7

--- a/protocols/10x-chromium-3p-v3/10x-chromium-3p-v3-quant.jsonnet
+++ b/protocols/10x-chromium-3p-v3/10x-chromium-3p-v3-quant.jsonnet
@@ -19,9 +19,6 @@ local meta_info = {
 	# number of threads for all commands
 	threads : 16, # change to other integer if needed # This defines `simpleaf index/quant --threads`
 
-	# boolean, true or false
-	use_piscem : false, # or use_piscem: false # This defines `simpleaf index/quant --use-piscem`
-
 	# Output directory.
 	output: output, # or output: "/path/to/output/dir" # this defines `simpleaf index/quant --output`
 };
@@ -77,10 +74,9 @@ local template = {
 				"--keep-duplicates" : false,
 				"--gff3-fomrat" : false,
 				"--threads" : $.meta_info.threads,
-				"--use-piscem" : $.meta_info.use_piscem, 
-				"--overwrite" : $.meta_info.use_piscem,
+				"--overwrite" : false,
 				"--kmer-length" :  31,
-				"--minimizer-length" : utils.ml($.meta_info.use_piscem, std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
+				"--minimizer-length" : utils.ml(std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
 				"--decoy-paths" : null, # only if using piscem >= 0.7
 			},
 
@@ -128,9 +124,7 @@ local template = {
 				"--expected-ori" :  "fw",
 				"--threads" :  $.meta_info.threads,
 				"--chemistry" :  "10xv3",
-				"--use-selective-alignment" : false, # only if using salmon alevin as theunderlying mapper
 				# piscem options
-				"--use-piscem" : $.meta_info.use_piscem,
 				"--struct-constraints" : false,
 				"--ignore-ambig-hits" : false,
 				"--no-poison" : false,

--- a/protocols/10x-chromium-3p-v3/10x-chromium-3p-v3-quant.jsonnet
+++ b/protocols/10x-chromium-3p-v3/10x-chromium-3p-v3-quant.jsonnet
@@ -74,8 +74,8 @@ local template = {
 				"--keep-duplicates" : false,
 				"--gff3-fomrat" : false,
 				"--threads" : $.meta_info.threads,
-				"--overwrite" : false,
-				"--work-dir" : $.meta_info.output + "/simpleaf_index/workdir",
+				"--overwrite" : true,
+				"--work-dir" : null,
 				"--kmer-length" :  31,
 				"--minimizer-length" : utils.ml(std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
 				"--decoy-paths" : null, # only if using piscem >= 0.7

--- a/protocols/10x-chromium-3p-v3/10x-chromium-3p-v3.jsonnet
+++ b/protocols/10x-chromium-3p-v3/10x-chromium-3p-v3.jsonnet
@@ -19,9 +19,6 @@ local meta_info = {
 	# number of threads for all commands
 	threads : 16, # change to other integer if needed # This defines `simpleaf index/quant --threads`
 
-	# boolean, true or false
-	use_piscem : false, # or use_piscem: false # This defines `simpleaf index/quant --use-piscem`
-
 	# Output directory. Do not change if setting `--output` from command line
 	output: output, # or output: "/path/to/output/dir" # this defines `simpleaf index/quant --output`
 };
@@ -99,10 +96,9 @@ local template = {
 				"--keep-duplicates" : false,
 				"--gff3-fomrat" : false,
 				"--threads" : $.meta_info.threads,
-				"--use-piscem" : $.meta_info.use_piscem, 
-				"--overwrite" : $.meta_info.use_piscem,
+				"--overwrite" : false,
 				"--kmer-length" :  31,
-				"--minimizer-length" : utils.ml($.meta_info.use_piscem, std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
+				"--minimizer-length" : utils.ml(std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
 				"--decoy-paths" : null, # only if using piscem >= 0.7
 			},
 
@@ -150,9 +146,7 @@ local template = {
 				"--expected-ori" :  "fw",
 				"--threads" :  $.meta_info.threads,
 				"--chemistry" :  "10xv3",
-				"--use-selective-alignment" : false, # only if using salmon alevin as theunderlying mapper
 				# piscem options
-				"--use-piscem" : $.meta_info.use_piscem,
 				"--struct-constraints" : false,
 				"--ignore-ambig-hits" : false,
 				"--no-poison" : false,

--- a/protocols/10x-chromium-3p-v3/10x-chromium-3p-v3.jsonnet
+++ b/protocols/10x-chromium-3p-v3/10x-chromium-3p-v3.jsonnet
@@ -97,6 +97,7 @@ local template = {
 				"--gff3-fomrat" : false,
 				"--threads" : $.meta_info.threads,
 				"--overwrite" : false,
+				"--work-dir" : $.meta_info.output + "/simpleaf_index/workdir",
 				"--kmer-length" :  31,
 				"--minimizer-length" : utils.ml(std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
 				"--decoy-paths" : null, # only if using piscem >= 0.7

--- a/protocols/10x-chromium-3p-v3/10x-chromium-3p-v3.jsonnet
+++ b/protocols/10x-chromium-3p-v3/10x-chromium-3p-v3.jsonnet
@@ -96,8 +96,8 @@ local template = {
 				"--keep-duplicates" : false,
 				"--gff3-fomrat" : false,
 				"--threads" : $.meta_info.threads,
-				"--overwrite" : false,
-				"--work-dir" : $.meta_info.output + "/simpleaf_index/workdir",
+				"--overwrite" : true,
+				"--work-dir" : null,
 				"--kmer-length" :  31,
 				"--minimizer-length" : utils.ml(std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
 				"--decoy-paths" : null, # only if using piscem >= 0.7

--- a/protocols/10x-feature-barcode-antibody+crispr/10x-feature-barcode-antibody+crispr.jsonnet
+++ b/protocols/10x-feature-barcode-antibody+crispr/10x-feature-barcode-antibody+crispr.jsonnet
@@ -19,9 +19,6 @@ local meta_info = {
     # number of threads for all commands
     threads : 16, # change to other integer if needed # This defines `simpleaf index/quant --threads`
 
-    # boolean, true or false
-    use_piscem : false, # or use_piscem: false # This defines `simpleaf index/quant --use-piscem`
-
     # Output directory. Do not change if setting `--output` from command line
     output: output, # or output: "/path/to/output/dir" # this defines `simpleaf index/quant --output`
 };
@@ -133,10 +130,9 @@ local template = {
                     "--sparse" : false,
                     "--gff3-fomrat" : false,
                     "--threads" : $.meta_info.threads,
-                    "--use-piscem" : $.meta_info.use_piscem, 
-                    "--overwrite" : $.meta_info.use_piscem,
+                    "--overwrite" : false,
                     "--kmer-length" :  31,
-                    "--minimizer-length" : utils.ml($.meta_info.use_piscem, std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
+                    "--minimizer-length" : utils.ml(std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
                     "--decoy-paths" : null, # only if using piscem >= 0.7
                 },
 
@@ -184,9 +180,6 @@ local template = {
                     "--expected-ori" :  "fw",
                     "--threads" :  $.meta_info.threads,
                     "--chemistry" :  "10xv3",
-                    "--use-selective-alignment" : false, # only if using salmon alevin as theunderlying mapper
-                    # piscem options
-                    "--use-piscem" : $.meta_info.use_piscem,
                     "--struct-constraints" : false,
                     "--ignore-ambig-hits" : false,
                     "--no-poison" : false,
@@ -239,10 +232,9 @@ local template = {
                     "--sparse" : false,
                     "--keep-duplicates" : false,
                     "--threads" : $.meta_info.threads,
-                    "--use-piscem" : $.meta_info.use_piscem, 
-                    "--overwrite" : $.meta_info.use_piscem,
+                    "--overwrite" : false,
                     "--kmer-length" :  7,
-                    "--minimizer-length" : utils.ml($.meta_info.use_piscem, std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
+                    "--minimizer-length" : utils.ml(std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
                     "--decoy-paths" : null, # only if using piscem >= 0.7
                 },
 
@@ -291,9 +283,6 @@ local template = {
                     "--expected-ori" :  "fw",
                     "--threads" :  $.meta_info.threads,
                     "--chemistry" :  "1{b[16]u[12]}2{x[10]r[15]x:}",
-                    "--use-selective-alignment" : false, # only if using salmon alevin as theunderlying mapper
-                    # piscem options
-                    "--use-piscem" : $.meta_info.use_piscem,
                     "--struct-constraints" : false,
                     "--ignore-ambig-hits" : false,
                     "--no-poison" : false,
@@ -346,10 +335,9 @@ local template = {
                     "--sparse" : false,
                     "--keep-duplicates" : false,
                     "--threads" : $.meta_info.threads,
-                    "--use-piscem" : $.meta_info.use_piscem, 
-                    "--overwrite" : $.meta_info.use_piscem,
+                    "--overwrite" : false,
                     "--kmer-length" :  7,
-                    "--minimizer-length" : utils.ml($.meta_info.use_piscem, std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
+                    "--minimizer-length" : utils.ml(std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
                     "--decoy-paths" : null, # only if using piscem >= 0.7
                 },
 
@@ -398,9 +386,6 @@ local template = {
                     "--expected-ori" :  "fw",
                     "--threads" :  $.meta_info.threads,
                     "--chemistry" :  "1{b[16]u[12]}2{x:r[20]f[GTTTAAGAGCTAAGCTGGAA]x:}",
-                    "--use-selective-alignment" : false, # only if using salmon alevin as theunderlying mapper
-                    # piscem options
-                    "--use-piscem" : $.meta_info.use_piscem,
                     "--struct-constraints" : false,
                     "--ignore-ambig-hits" : false,
                     "--no-poison" : false,

--- a/protocols/10x-feature-barcode-antibody+crispr/10x-feature-barcode-antibody+crispr.jsonnet
+++ b/protocols/10x-feature-barcode-antibody+crispr/10x-feature-barcode-antibody+crispr.jsonnet
@@ -131,6 +131,7 @@ local template = {
                     "--gff3-fomrat" : false,
                     "--threads" : $.meta_info.threads,
                     "--overwrite" : false,
+                    "--work-dir" : $.meta_info.output + "/gene_expression/simpleaf_index/workdir",
                     "--kmer-length" :  31,
                     "--minimizer-length" : utils.ml(std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
                     "--decoy-paths" : null, # only if using piscem >= 0.7
@@ -233,6 +234,7 @@ local template = {
                     "--keep-duplicates" : false,
                     "--threads" : $.meta_info.threads,
                     "--overwrite" : false,
+                    "--work-dir" : $.meta_info.output + "/antibody_capture/simpleaf_index/workdir",
                     "--kmer-length" :  7,
                     "--minimizer-length" : utils.ml(std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
                     "--decoy-paths" : null, # only if using piscem >= 0.7
@@ -336,6 +338,7 @@ local template = {
                     "--keep-duplicates" : false,
                     "--threads" : $.meta_info.threads,
                     "--overwrite" : false,
+                    "--work-dir" : $.meta_info.output + "/crispr_screen/simpleaf_index/workdir",
                     "--kmer-length" :  7,
                     "--minimizer-length" : utils.ml(std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
                     "--decoy-paths" : null, # only if using piscem >= 0.7

--- a/protocols/10x-feature-barcode-antibody+crispr/10x-feature-barcode-antibody+crispr.jsonnet
+++ b/protocols/10x-feature-barcode-antibody+crispr/10x-feature-barcode-antibody+crispr.jsonnet
@@ -130,8 +130,8 @@ local template = {
                     "--sparse" : false,
                     "--gff3-fomrat" : false,
                     "--threads" : $.meta_info.threads,
-                    "--overwrite" : false,
-                    "--work-dir" : $.meta_info.output + "/gene_expression/simpleaf_index/workdir",
+                    "--overwrite" : true,
+                    "--work-dir" : null,
                     "--kmer-length" :  31,
                     "--minimizer-length" : utils.ml(std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
                     "--decoy-paths" : null, # only if using piscem >= 0.7
@@ -233,8 +233,8 @@ local template = {
                     "--sparse" : false,
                     "--keep-duplicates" : false,
                     "--threads" : $.meta_info.threads,
-                    "--overwrite" : false,
-                    "--work-dir" : $.meta_info.output + "/antibody_capture/simpleaf_index/workdir",
+                    "--overwrite" : true,
+                    "--work-dir" : null,
                     "--kmer-length" :  7,
                     "--minimizer-length" : utils.ml(std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
                     "--decoy-paths" : null, # only if using piscem >= 0.7
@@ -337,8 +337,8 @@ local template = {
                     "--sparse" : false,
                     "--keep-duplicates" : false,
                     "--threads" : $.meta_info.threads,
-                    "--overwrite" : false,
-                    "--work-dir" : $.meta_info.output + "/crispr_screen/simpleaf_index/workdir",
+                    "--overwrite" : true,
+                    "--work-dir" : null,
                     "--kmer-length" :  7,
                     "--minimizer-length" : utils.ml(std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
                     "--decoy-paths" : null, # only if using piscem >= 0.7

--- a/protocols/10x-feature-barcode-antibody+crispr/10x-feature-barcode-antibody+crispr.jsonnet
+++ b/protocols/10x-feature-barcode-antibody+crispr/10x-feature-barcode-antibody+crispr.jsonnet
@@ -483,7 +483,7 @@ local template = {
         external_commands : {
             barcode_translation : utils.barcode_translation(
                 3, 
-                "https://github.com/10XGenomics/cellranger/raw/master/lib/python/cellranger/barcodes/translation/3M-february-2018.txt.gz", 
+                "https://github.com/COMBINE-lab/protocol-estuary/raw/main/resources/translation_3M-february-2018.txt.gz", 
                 $.advanced_config.gene_expression.simpleaf_quant.output + "/af_quant/alevin/quants_mat_rows.txt",
                 $.advanced_config.gene_expression.simpleaf_quant.output
             ),

--- a/protocols/10x-feature-barcode-antibody/10x-feature-barcode-antibody.jsonnet
+++ b/protocols/10x-feature-barcode-antibody/10x-feature-barcode-antibody.jsonnet
@@ -116,8 +116,8 @@ local template = {
                     "--sparse" : false,
 				    "--gff3-fomrat" : false,
                     "--threads" : $.meta_info.threads,
-                    "--overwrite" : false,
-                    "--work-dir" : $.meta_info.output + "/gene_expression/simpleaf_index/workdir",
+                    "--overwrite" : true,
+                    "--work-dir" : null,
                     "--kmer-length" :  31,
                     "--minimizer-length" : utils.ml(std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
                     "--decoy-paths" : null, # only if using piscem >= 0.7
@@ -219,8 +219,8 @@ local template = {
                     "--sparse" : false,
                     "--keep-duplicates" : false,
                     "--threads" : $.meta_info.threads,
-                    "--overwrite" : false,
-                    "--work-dir" : $.meta_info.output + "/antibody_capture/simpleaf_index/workdir",
+                    "--overwrite" : true,
+                    "--work-dir" : null,
                     "--kmer-length" :  7,
                     "--minimizer-length" : utils.ml(std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
                     "--decoy-paths" : null, # only if using piscem >= 0.7

--- a/protocols/10x-feature-barcode-antibody/10x-feature-barcode-antibody.jsonnet
+++ b/protocols/10x-feature-barcode-antibody/10x-feature-barcode-antibody.jsonnet
@@ -19,9 +19,6 @@ local meta_info = {
     # number of threads for all commands
     threads : 16, # change to other integer if needed # This defines `simpleaf index/quant --threads`
 
-    # boolean, true or false
-    use_piscem : false, # or use_piscem: false # This defines `simpleaf index/quant --use-piscem`
-
     # Output directory. Do not change if setting `--output` from command line
     output: output, # or output: "/path/to/output/dir" # this defines `simpleaf index/quant --output`
 };
@@ -119,10 +116,9 @@ local template = {
                     "--sparse" : false,
 				    "--gff3-fomrat" : false,
                     "--threads" : $.meta_info.threads,
-                    "--use-piscem" : $.meta_info.use_piscem, 
-                    "--overwrite" : $.meta_info.use_piscem,
+                    "--overwrite" : false,
                     "--kmer-length" :  31,
-                    "--minimizer-length" : utils.ml($.meta_info.use_piscem, std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
+                    "--minimizer-length" : utils.ml(std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
                     "--decoy-paths" : null, # only if using piscem >= 0.7
                 },
 
@@ -170,9 +166,6 @@ local template = {
                     "--expected-ori" :  "fw",
                     "--threads" :  $.meta_info.threads,
                     "--chemistry" :  "10xv3",
-                    "--use-selective-alignment" : false, # only if using salmon alevin as theunderlying mapper
-                    # piscem options
-                    "--use-piscem" : $.meta_info.use_piscem,
                     "--struct-constraints" : false,
                     "--ignore-ambig-hits" : false,
                     "--no-poison" : false,
@@ -225,10 +218,9 @@ local template = {
                     "--sparse" : false,
                     "--keep-duplicates" : false,
                     "--threads" : $.meta_info.threads,
-                    "--use-piscem" : $.meta_info.use_piscem, 
-                    "--overwrite" : $.meta_info.use_piscem,
+                    "--overwrite" : false,
                     "--kmer-length" :  7,
-                    "--minimizer-length" : utils.ml($.meta_info.use_piscem, std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
+                    "--minimizer-length" : utils.ml(std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
                     "--decoy-paths" : null, # only if using piscem >= 0.7
                 },
 
@@ -277,9 +269,6 @@ local template = {
                     "--expected-ori" :  "fw",
                     "--threads" :  $.meta_info.threads,
                     "--chemistry" :  "1{b[16]u[12]}2{x[10]r[15]x:}",
-                    "--use-selective-alignment" : false, # only if using salmon alevin as theunderlying mapper
-                    # piscem options
-                    "--use-piscem" : $.meta_info.use_piscem,
                     "--struct-constraints" : false,
                     "--ignore-ambig-hits" : false,
                     "--no-poison" : false,

--- a/protocols/10x-feature-barcode-antibody/10x-feature-barcode-antibody.jsonnet
+++ b/protocols/10x-feature-barcode-antibody/10x-feature-barcode-antibody.jsonnet
@@ -347,7 +347,7 @@ local template = {
         external_commands : {
             barcode_translation : utils.barcode_translation(
                 3, 
-                "https://github.com/10XGenomics/cellranger/raw/master/lib/python/cellranger/barcodes/translation/3M-february-2018.txt.gz", 
+                "https://github.com/COMBINE-lab/protocol-estuary/raw/main/resources/translation_3M-february-2018.txt.gz", 
                 $.advanced_config.gene_expression.simpleaf_quant.output + "/af_quant/alevin/quants_mat_rows.txt",
                 $.advanced_config.gene_expression.simpleaf_quant.output
             ),

--- a/protocols/10x-feature-barcode-antibody/10x-feature-barcode-antibody.jsonnet
+++ b/protocols/10x-feature-barcode-antibody/10x-feature-barcode-antibody.jsonnet
@@ -117,6 +117,7 @@ local template = {
 				    "--gff3-fomrat" : false,
                     "--threads" : $.meta_info.threads,
                     "--overwrite" : false,
+                    "--work-dir" : $.meta_info.output + "/gene_expression/simpleaf_index/workdir",
                     "--kmer-length" :  31,
                     "--minimizer-length" : utils.ml(std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
                     "--decoy-paths" : null, # only if using piscem >= 0.7
@@ -219,6 +220,7 @@ local template = {
                     "--keep-duplicates" : false,
                     "--threads" : $.meta_info.threads,
                     "--overwrite" : false,
+                    "--work-dir" : $.meta_info.output + "/antibody_capture/simpleaf_index/workdir",
                     "--kmer-length" :  7,
                     "--minimizer-length" : utils.ml(std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
                     "--decoy-paths" : null, # only if using piscem >= 0.7

--- a/protocols/10x-feature-barcode-crispr/10x-feature-barcode-crispr.jsonnet
+++ b/protocols/10x-feature-barcode-crispr/10x-feature-barcode-crispr.jsonnet
@@ -117,6 +117,7 @@ local template = {
 				    "--gff3-fomrat" : false,
                     "--threads" : $.meta_info.threads,
                     "--overwrite" : false,
+                    "--work-dir" : $.meta_info.output + "/gene_expression/simpleaf_index/workdir",
                     "--kmer-length" :  31,
                     "--minimizer-length" : utils.ml(std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
                     "--decoy-paths" : null, # only if using piscem >= 0.7
@@ -219,6 +220,7 @@ local template = {
                     "--keep-duplicates" : false,
                     "--threads" : $.meta_info.threads,
                     "--overwrite" : false,
+                    "--work-dir" : $.meta_info.output + "/crispr_screen/simpleaf_index/workdir",
                     "--kmer-length" :  7,
                     "--minimizer-length" : utils.ml(std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
                     "--decoy-paths" : null, # only if using piscem >= 0.7

--- a/protocols/10x-feature-barcode-crispr/10x-feature-barcode-crispr.jsonnet
+++ b/protocols/10x-feature-barcode-crispr/10x-feature-barcode-crispr.jsonnet
@@ -116,8 +116,8 @@ local template = {
                     "--sparse" : false,
 				    "--gff3-fomrat" : false,
                     "--threads" : $.meta_info.threads,
-                    "--overwrite" : false,
-                    "--work-dir" : $.meta_info.output + "/gene_expression/simpleaf_index/workdir",
+                    "--overwrite" : true,
+                    "--work-dir" : null,
                     "--kmer-length" :  31,
                     "--minimizer-length" : utils.ml(std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
                     "--decoy-paths" : null, # only if using piscem >= 0.7
@@ -219,8 +219,8 @@ local template = {
                     "--sparse" : false,
                     "--keep-duplicates" : false,
                     "--threads" : $.meta_info.threads,
-                    "--overwrite" : false,
-                    "--work-dir" : $.meta_info.output + "/crispr_screen/simpleaf_index/workdir",
+                    "--overwrite" : true,
+                    "--work-dir" : null,
                     "--kmer-length" :  7,
                     "--minimizer-length" : utils.ml(std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
                     "--decoy-paths" : null, # only if using piscem >= 0.7

--- a/protocols/10x-feature-barcode-crispr/10x-feature-barcode-crispr.jsonnet
+++ b/protocols/10x-feature-barcode-crispr/10x-feature-barcode-crispr.jsonnet
@@ -347,7 +347,7 @@ local template = {
         external_commands : {
             barcode_translation : utils.barcode_translation(
                 3, 
-                "https://github.com/10XGenomics/cellranger/raw/master/lib/python/cellranger/barcodes/translation/3M-february-2018.txt.gz", 
+                "https://github.com/COMBINE-lab/protocol-estuary/raw/main/resources/translation_3M-february-2018.txt.gz", 
                 $.advanced_config.gene_expression.simpleaf_quant.output + "/af_quant/alevin/quants_mat_rows.txt",
                 $.advanced_config.gene_expression.simpleaf_quant.output
             ),

--- a/protocols/10x-feature-barcode-crispr/10x-feature-barcode-crispr.jsonnet
+++ b/protocols/10x-feature-barcode-crispr/10x-feature-barcode-crispr.jsonnet
@@ -19,9 +19,6 @@ local meta_info = {
     # number of threads for all commands
     threads : 16, # change to other integer if needed # This defines `simpleaf index/quant --threads`
 
-    # boolean, true or false
-    use_piscem : false, # or use_piscem: false # This defines `simpleaf index/quant --use-piscem`
-
     # Output directory. Do not change if setting `--output` from command line
     output: output, # or output: "/path/to/output/dir" # this defines `simpleaf index/quant --output`
 };
@@ -119,10 +116,9 @@ local template = {
                     "--sparse" : false,
 				    "--gff3-fomrat" : false,
                     "--threads" : $.meta_info.threads,
-                    "--use-piscem" : $.meta_info.use_piscem, 
-                    "--overwrite" : $.meta_info.use_piscem,
+                    "--overwrite" : false,
                     "--kmer-length" :  31,
-                    "--minimizer-length" : utils.ml($.meta_info.use_piscem, std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
+                    "--minimizer-length" : utils.ml(std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
                     "--decoy-paths" : null, # only if using piscem >= 0.7
                 },
 
@@ -170,9 +166,6 @@ local template = {
                     "--expected-ori" :  "fw",
                     "--threads" :  $.meta_info.threads,
                     "--chemistry" :  "10xv3",
-                    "--use-selective-alignment" : false, # only if using salmon alevin as theunderlying mapper
-                    # piscem options
-                    "--use-piscem" : $.meta_info.use_piscem,
                     "--struct-constraints" : false,
                     "--ignore-ambig-hits" : false,
                     "--no-poison" : false,
@@ -225,10 +218,9 @@ local template = {
                     "--sparse" : false,
                     "--keep-duplicates" : false,
                     "--threads" : $.meta_info.threads,
-                    "--use-piscem" : $.meta_info.use_piscem, 
-                    "--overwrite" : $.meta_info.use_piscem,
+                    "--overwrite" : false,
                     "--kmer-length" :  7,
-                    "--minimizer-length" : utils.ml($.meta_info.use_piscem, std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
+                    "--minimizer-length" : utils.ml(std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
                     "--decoy-paths" : null, # only if using piscem >= 0.7
                 },
 
@@ -277,9 +269,6 @@ local template = {
                     "--expected-ori" :  "fw",
                     "--threads" :  $.meta_info.threads,
                     "--chemistry" :  "1{b[16]u[12]}2{x:r[20]f[GTTTAAGAGCTAAGCTGGAA]x:}",
-                    "--use-selective-alignment" : false, # only if using salmon alevin as theunderlying mapper
-                    # piscem options
-                    "--use-piscem" : $.meta_info.use_piscem,
                     "--struct-constraints" : false,
                     "--ignore-ambig-hits" : false,
                     "--no-poison" : false,

--- a/protocols/cite-seq-ADT+HTO_10xv2/cite-seq-ADT+HTO_10xv2.jsonnet
+++ b/protocols/cite-seq-ADT+HTO_10xv2/cite-seq-ADT+HTO_10xv2.jsonnet
@@ -130,8 +130,8 @@ local template = {
                     "--sparse" : false,
                     "--keep-duplicates" : false,
                     "--threads" : $.meta_info.threads,
-                    "--overwrite" : false,
-                    "--work-dir" : $.meta_info.output + "/gene_expression/simpleaf_index/workdir",
+                    "--overwrite" : true,
+                    "--work-dir" : null,
                     "--kmer-length" :  31,
                     "--minimizer-length" : utils.ml(std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
                     "--decoy-paths" : null, # only if using piscem >= 0.7
@@ -225,8 +225,8 @@ local template = {
                     "--sparse" : false,
                     "--keep-duplicates" : false,
                     "--threads" : $.meta_info.threads,
-                    "--overwrite" : false,
-                    "--work-dir" : $.meta_info.output + "/ADT/simpleaf_index/workdir",
+                    "--overwrite" : true,
+                    "--work-dir" : null,
                     "--kmer-length" :  7,
                     "--minimizer-length" : utils.ml(std.get($.advanced_config.ADT.simpleaf_index.arguments, "--kmer-length")), # a quick way to calculate minimizer length
                 },
@@ -320,8 +320,8 @@ local template = {
                     "--sparse" : false,
                     "--keep-duplicates" : false,
                     "--threads" : $.meta_info.threads,
-                    "--overwrite" : false,
-                    "--work-dir" : $.meta_info.output + "/HTO/simpleaf_index/workdir",
+                    "--overwrite" : true,
+                    "--work-dir" : null,
                     "--kmer-length" :  7,
                     "--minimizer-length" : utils.ml(std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
                     "--decoy-paths" : null, # only if using piscem >= 0.7

--- a/protocols/cite-seq-ADT+HTO_10xv2/cite-seq-ADT+HTO_10xv2.jsonnet
+++ b/protocols/cite-seq-ADT+HTO_10xv2/cite-seq-ADT+HTO_10xv2.jsonnet
@@ -131,6 +131,7 @@ local template = {
                     "--keep-duplicates" : false,
                     "--threads" : $.meta_info.threads,
                     "--overwrite" : false,
+                    "--work-dir" : $.meta_info.output + "/gene_expression/simpleaf_index/workdir",
                     "--kmer-length" :  31,
                     "--minimizer-length" : utils.ml(std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
                     "--decoy-paths" : null, # only if using piscem >= 0.7
@@ -225,6 +226,7 @@ local template = {
                     "--keep-duplicates" : false,
                     "--threads" : $.meta_info.threads,
                     "--overwrite" : false,
+                    "--work-dir" : $.meta_info.output + "/ADT/simpleaf_index/workdir",
                     "--kmer-length" :  7,
                     "--minimizer-length" : utils.ml(std.get($.advanced_config.ADT.simpleaf_index.arguments, "--kmer-length")), # a quick way to calculate minimizer length
                 },
@@ -319,6 +321,7 @@ local template = {
                     "--keep-duplicates" : false,
                     "--threads" : $.meta_info.threads,
                     "--overwrite" : false,
+                    "--work-dir" : $.meta_info.output + "/HTO/simpleaf_index/workdir",
                     "--kmer-length" :  7,
                     "--minimizer-length" : utils.ml(std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
                     "--decoy-paths" : null, # only if using piscem >= 0.7

--- a/protocols/cite-seq-ADT+HTO_10xv2/cite-seq-ADT+HTO_10xv2.jsonnet
+++ b/protocols/cite-seq-ADT+HTO_10xv2/cite-seq-ADT+HTO_10xv2.jsonnet
@@ -19,9 +19,6 @@ local meta_info = {
     # number of threads for all commands
     threads : 16, # change to other integer if needed # This defines `simpleaf index/quant --threads`
 
-    # boolean, true or false
-    use_piscem : false, # or use_piscem: false # This defines `simpleaf index/quant --use-piscem`
-
     # Output directory. Do not change if setting `--output` from command line
     output: output, # or output: "/path/to/output/dir" # this defines `simpleaf index/quant --output`
 };
@@ -133,10 +130,9 @@ local template = {
                     "--sparse" : false,
                     "--keep-duplicates" : false,
                     "--threads" : $.meta_info.threads,
-                    "--use-piscem" : $.meta_info.use_piscem, 
-                    "--overwrite" : $.meta_info.use_piscem,
+                    "--overwrite" : false,
                     "--kmer-length" :  31,
-                    "--minimizer-length" : utils.ml($.meta_info.use_piscem, std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
+                    "--minimizer-length" : utils.ml(std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
                     "--decoy-paths" : null, # only if using piscem >= 0.7
                 },
 
@@ -183,7 +179,6 @@ local template = {
                     "--resolution" :  "cr-like",
                     "--expected-ori" :  "fw",
                     "--threads" :  $.meta_info.threads,
-                    "--use-piscem" : $.meta_info.use_piscem,
                     "--chemistry" :  "10xv2",
                 },
 
@@ -229,10 +224,9 @@ local template = {
                     "--sparse" : false,
                     "--keep-duplicates" : false,
                     "--threads" : $.meta_info.threads,
-                    "--use-piscem" : $.meta_info.use_piscem, 
-                    "--overwrite" : $.meta_info.use_piscem,
+                    "--overwrite" : false,
                     "--kmer-length" :  7,
-                    "--minimizer-length" : utils.ml($.meta_info.use_piscem, std.get($.advanced_config.ADT.simpleaf_index.arguments, "--kmer-length")), # a quick way to calculate minimizer length
+                    "--minimizer-length" : utils.ml(std.get($.advanced_config.ADT.simpleaf_index.arguments, "--kmer-length")), # a quick way to calculate minimizer length
                 },
 
             #-----------------------------------------------------------------------#
@@ -279,7 +273,6 @@ local template = {
                     "--resolution" :  "cr-like",
                     "--expected-ori" :  "fw",
                     "--threads" :  $.meta_info.threads,
-                    "--use-piscem" : $.meta_info.use_piscem,
                     "--chemistry" :  "1{b[16]u[10]}2{r[15]}",
                 },
 
@@ -325,10 +318,9 @@ local template = {
                     "--sparse" : false,
                     "--keep-duplicates" : false,
                     "--threads" : $.meta_info.threads,
-                    "--use-piscem" : $.meta_info.use_piscem, 
-                    "--overwrite" : $.meta_info.use_piscem,
+                    "--overwrite" : false,
                     "--kmer-length" :  7,
-                    "--minimizer-length" : utils.ml($.meta_info.use_piscem, std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
+                    "--minimizer-length" : utils.ml(std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
                     "--decoy-paths" : null, # only if using piscem >= 0.7
                 },
 
@@ -376,7 +368,6 @@ local template = {
                     "--resolution" :  "cr-like",
                     "--expected-ori" :  "fw",
                     "--threads" :  $.meta_info.threads,
-                    "--use-piscem" : $.meta_info.use_piscem,
                     "--chemistry" :  "1{b[16]u[10]}2{r[15]}",
                 },
 

--- a/protocols/cite-seq-ADT+HTO_10xv3/cite-seq-ADT+HTO_10xv3.jsonnet
+++ b/protocols/cite-seq-ADT+HTO_10xv3/cite-seq-ADT+HTO_10xv3.jsonnet
@@ -131,6 +131,7 @@ local template = {
 				    "--gff3-fomrat" : false,
                     "--threads" : $.meta_info.threads,
                     "--overwrite" : false,
+                    "--work-dir" : $.meta_info.output + "/gene_expression/simpleaf_index/workdir",
                     "--kmer-length" :  31,
                     "--minimizer-length" : utils.ml(std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
                     "--decoy-paths" : null, # only if using piscem >= 0.7
@@ -233,6 +234,7 @@ local template = {
                     "--keep-duplicates" : false,
                     "--threads" : $.meta_info.threads,
                     "--overwrite" : false,
+                    "--work-dir" : $.meta_info.output + "/ADT/simpleaf_index/workdir",
                     "--kmer-length" :  7,
                     "--minimizer-length" : utils.ml(std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
                     "--decoy-paths" : null, # only if using piscem >= 0.7
@@ -328,6 +330,7 @@ local template = {
                     "--keep-duplicates" : false,
                     "--threads" : $.meta_info.threads,
                     "--overwrite" : false,
+                    "--work-dir" : $.meta_info.output + "/HTO/simpleaf_index/workdir",
                     "--kmer-length" :  7,
                     "--minimizer-length" : utils.ml(std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
                     "--decoy-paths" : null, # only if using piscem >= 0.7

--- a/protocols/cite-seq-ADT+HTO_10xv3/cite-seq-ADT+HTO_10xv3.jsonnet
+++ b/protocols/cite-seq-ADT+HTO_10xv3/cite-seq-ADT+HTO_10xv3.jsonnet
@@ -130,8 +130,8 @@ local template = {
                     "--sparse" : false,
 				    "--gff3-fomrat" : false,
                     "--threads" : $.meta_info.threads,
-                    "--overwrite" : false,
-                    "--work-dir" : $.meta_info.output + "/gene_expression/simpleaf_index/workdir",
+                    "--overwrite" : true,
+                    "--work-dir" : null,
                     "--kmer-length" :  31,
                     "--minimizer-length" : utils.ml(std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
                     "--decoy-paths" : null, # only if using piscem >= 0.7
@@ -233,8 +233,8 @@ local template = {
                     "--sparse" : false,
                     "--keep-duplicates" : false,
                     "--threads" : $.meta_info.threads,
-                    "--overwrite" : false,
-                    "--work-dir" : $.meta_info.output + "/ADT/simpleaf_index/workdir",
+                    "--overwrite" : true,
+                    "--work-dir" : null,
                     "--kmer-length" :  7,
                     "--minimizer-length" : utils.ml(std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
                     "--decoy-paths" : null, # only if using piscem >= 0.7
@@ -329,8 +329,8 @@ local template = {
                     "--sparse" : false,
                     "--keep-duplicates" : false,
                     "--threads" : $.meta_info.threads,
-                    "--overwrite" : false,
-                    "--work-dir" : $.meta_info.output + "/HTO/simpleaf_index/workdir",
+                    "--overwrite" : true,
+                    "--work-dir" : null,
                     "--kmer-length" :  7,
                     "--minimizer-length" : utils.ml(std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
                     "--decoy-paths" : null, # only if using piscem >= 0.7

--- a/protocols/cite-seq-ADT+HTO_10xv3/cite-seq-ADT+HTO_10xv3.jsonnet
+++ b/protocols/cite-seq-ADT+HTO_10xv3/cite-seq-ADT+HTO_10xv3.jsonnet
@@ -19,9 +19,6 @@ local meta_info = {
     # number of threads for all commands
     threads : 16, # change to other integer if needed # This defines `simpleaf index/quant --threads`
 
-    # boolean, true or false
-    use_piscem : false, # or use_piscem: false # This defines `simpleaf index/quant --use-piscem`
-
     # Output directory. Do not change if setting `--output` from command line
     output: output, # or output: "/path/to/output/dir" # this defines `simpleaf index/quant --output`
 };
@@ -133,10 +130,9 @@ local template = {
                     "--sparse" : false,
 				    "--gff3-fomrat" : false,
                     "--threads" : $.meta_info.threads,
-                    "--use-piscem" : $.meta_info.use_piscem, 
-                    "--overwrite" : $.meta_info.use_piscem,
+                    "--overwrite" : false,
                     "--kmer-length" :  31,
-                    "--minimizer-length" : utils.ml($.meta_info.use_piscem, std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
+                    "--minimizer-length" : utils.ml(std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
                     "--decoy-paths" : null, # only if using piscem >= 0.7
                 },
 
@@ -184,9 +180,6 @@ local template = {
                     "--expected-ori" :  "fw",
                     "--threads" :  $.meta_info.threads,
                     "--chemistry" :  "10xv3",
-                    "--use-selective-alignment" : false, # only if using salmon alevin as theunderlying mapper
-                    # piscem options
-                    "--use-piscem" : $.meta_info.use_piscem,
                     "--struct-constraints" : false,
                     "--ignore-ambig-hits" : false,
                     "--no-poison" : false,
@@ -239,10 +232,9 @@ local template = {
                     "--sparse" : false,
                     "--keep-duplicates" : false,
                     "--threads" : $.meta_info.threads,
-                    "--use-piscem" : $.meta_info.use_piscem, 
-                    "--overwrite" : $.meta_info.use_piscem,
+                    "--overwrite" : false,
                     "--kmer-length" :  7,
-                    "--minimizer-length" : utils.ml($.meta_info.use_piscem, std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
+                    "--minimizer-length" : utils.ml(std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
                     "--decoy-paths" : null, # only if using piscem >= 0.7
                 },
 
@@ -290,7 +282,6 @@ local template = {
                     "--resolution" :  "cr-like",
                     "--expected-ori" :  "fw",
                     "--threads" :  $.meta_info.threads,
-                    "--use-piscem" : $.meta_info.use_piscem,
                     "--chemistry" :  "1{b[16]u[12]}2{r[15]}",
                 },
 
@@ -336,10 +327,9 @@ local template = {
                     "--sparse" : false,
                     "--keep-duplicates" : false,
                     "--threads" : $.meta_info.threads,
-                    "--use-piscem" : $.meta_info.use_piscem, 
-                    "--overwrite" : $.meta_info.use_piscem,
+                    "--overwrite" : false,
                     "--kmer-length" :  7,
-                    "--minimizer-length" : utils.ml($.meta_info.use_piscem, std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
+                    "--minimizer-length" : utils.ml(std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
                     "--decoy-paths" : null, # only if using piscem >= 0.7
                 },
 
@@ -387,7 +377,6 @@ local template = {
                     "--resolution" :  "cr-like",
                     "--expected-ori" :  "fw",
                     "--threads" :  $.meta_info.threads,
-                    "--use-piscem" : $.meta_info.use_piscem,
                     "--chemistry" :  "1{b[16]u[12]}2{r[15]}",
                 },
 

--- a/protocols/cite-seq-ADT_10xv2/cite-seq-ADT_10xv2.jsonnet
+++ b/protocols/cite-seq-ADT_10xv2/cite-seq-ADT_10xv2.jsonnet
@@ -116,8 +116,8 @@ local template = {
                     "--sparse" : false,
 				    "--gff3-fomrat" : false,
                     "--threads" : $.meta_info.threads,
-                    "--overwrite" : false,
-                    "--work-dir" : $.meta_info.output + "/gene_expression/simpleaf_index/workdir",
+                    "--overwrite" : true,
+                    "--work-dir" : null,
                     "--kmer-length" :  31,
                     "--minimizer-length" : utils.ml(std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
                     "--decoy-paths" : null, # only if using piscem >= 0.7
@@ -211,8 +211,8 @@ local template = {
                     "--sparse" : false,
                     "--keep-duplicates" : false,
                     "--threads" : $.meta_info.threads,
-                    "--overwrite" : false,
-                    "--work-dir" : $.meta_info.output + "/ADT/simpleaf_index/workdir",
+                    "--overwrite" : true,
+                    "--work-dir" : null,
                     "--kmer-length" :  7,
                     "--minimizer-length" : utils.ml(std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
                     "--decoy-paths" : null, # only if using piscem >= 0.7

--- a/protocols/cite-seq-ADT_10xv2/cite-seq-ADT_10xv2.jsonnet
+++ b/protocols/cite-seq-ADT_10xv2/cite-seq-ADT_10xv2.jsonnet
@@ -19,9 +19,6 @@ local meta_info = {
     # number of threads for all commands
     threads : 16, # change to other integer if needed # This defines `simpleaf index/quant --threads`
 
-    # boolean, true or false
-    use_piscem : false, # or use_piscem: false # This defines `simpleaf index/quant --use-piscem`
-
     # Output directory. Do not change if setting `--output` from command line
     output: output, # or output: "/path/to/output/dir" # this defines `simpleaf index/quant --output`
 };
@@ -119,10 +116,9 @@ local template = {
                     "--sparse" : false,
 				    "--gff3-fomrat" : false,
                     "--threads" : $.meta_info.threads,
-                    "--use-piscem" : $.meta_info.use_piscem, 
-                    "--overwrite" : $.meta_info.use_piscem,
+                    "--overwrite" : false,
                     "--kmer-length" :  31,
-                    "--minimizer-length" : utils.ml($.meta_info.use_piscem, std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
+                    "--minimizer-length" : utils.ml(std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
                     "--decoy-paths" : null, # only if using piscem >= 0.7
                 },
 
@@ -169,7 +165,6 @@ local template = {
                     "--resolution" :  "cr-like",
                     "--expected-ori" :  "fw",
                     "--threads" :  $.meta_info.threads,
-                    "--use-piscem" : $.meta_info.use_piscem,
                     "--chemistry" :  "10xv2",
                 },
 
@@ -215,10 +210,9 @@ local template = {
                     "--sparse" : false,
                     "--keep-duplicates" : false,
                     "--threads" : $.meta_info.threads,
-                    "--use-piscem" : $.meta_info.use_piscem, 
-                    "--overwrite" : $.meta_info.use_piscem,
+                    "--overwrite" : false,
                     "--kmer-length" :  7,
-                    "--minimizer-length" : utils.ml($.meta_info.use_piscem, std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
+                    "--minimizer-length" : utils.ml(std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
                     "--decoy-paths" : null, # only if using piscem >= 0.7
                 },
 
@@ -266,7 +260,6 @@ local template = {
                     "--resolution" :  "cr-like",
                     "--expected-ori" :  "fw",
                     "--threads" :  $.meta_info.threads,
-                    "--use-piscem" : $.meta_info.use_piscem,
                     "--chemistry" :  "1{b[16]u[10]}2{r[15]}",
                 },
 

--- a/protocols/cite-seq-ADT_10xv2/cite-seq-ADT_10xv2.jsonnet
+++ b/protocols/cite-seq-ADT_10xv2/cite-seq-ADT_10xv2.jsonnet
@@ -117,6 +117,7 @@ local template = {
 				    "--gff3-fomrat" : false,
                     "--threads" : $.meta_info.threads,
                     "--overwrite" : false,
+                    "--work-dir" : $.meta_info.output + "/gene_expression/simpleaf_index/workdir",
                     "--kmer-length" :  31,
                     "--minimizer-length" : utils.ml(std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
                     "--decoy-paths" : null, # only if using piscem >= 0.7
@@ -211,6 +212,7 @@ local template = {
                     "--keep-duplicates" : false,
                     "--threads" : $.meta_info.threads,
                     "--overwrite" : false,
+                    "--work-dir" : $.meta_info.output + "/ADT/simpleaf_index/workdir",
                     "--kmer-length" :  7,
                     "--minimizer-length" : utils.ml(std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
                     "--decoy-paths" : null, # only if using piscem >= 0.7

--- a/protocols/cite-seq-ADT_10xv3/cite-seq-ADT_10xv3.jsonnet
+++ b/protocols/cite-seq-ADT_10xv3/cite-seq-ADT_10xv3.jsonnet
@@ -117,6 +117,7 @@ local template = {
 				    "--gff3-fomrat" : false,
                     "--threads" : $.meta_info.threads,
                     "--overwrite" : false,
+                    "--work-dir" : $.meta_info.output + "/gene_expression/simpleaf_index/workdir",
                     "--kmer-length" :  31,
                     "--minimizer-length" : utils.ml(std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
                     "--decoy-paths" : null, # only if using piscem >= 0.7
@@ -219,6 +220,7 @@ local template = {
                     "--keep-duplicates" : false,
                     "--threads" : $.meta_info.threads,
                     "--overwrite" : false,
+                    "--work-dir" : $.meta_info.output + "/ADT/simpleaf_index/workdir",
                     "--kmer-length" :  7,
                     "--minimizer-length" : utils.ml(std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
                     "--decoy-paths" : null, # only if using piscem >= 0.7

--- a/protocols/cite-seq-ADT_10xv3/cite-seq-ADT_10xv3.jsonnet
+++ b/protocols/cite-seq-ADT_10xv3/cite-seq-ADT_10xv3.jsonnet
@@ -19,9 +19,6 @@ local meta_info = {
     # number of threads for all commands
     threads : 16, # change to other integer if needed # This defines `simpleaf index/quant --threads`
 
-    # boolean, true or false
-    use_piscem : false, # or use_piscem: false # This defines `simpleaf index/quant --use-piscem`
-
     # Output directory. Do not change if setting `--output` from command line
     output: output, # or output: "/path/to/output/dir" # this defines `simpleaf index/quant --output`
 };
@@ -119,10 +116,9 @@ local template = {
                     "--sparse" : false,
 				    "--gff3-fomrat" : false,
                     "--threads" : $.meta_info.threads,
-                    "--use-piscem" : $.meta_info.use_piscem, 
-                    "--overwrite" : $.meta_info.use_piscem,
+                    "--overwrite" : false,
                     "--kmer-length" :  31,
-                    "--minimizer-length" : utils.ml($.meta_info.use_piscem, std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
+                    "--minimizer-length" : utils.ml(std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
                     "--decoy-paths" : null, # only if using piscem >= 0.7
                 },
 
@@ -170,9 +166,6 @@ local template = {
                     "--expected-ori" :  "fw",
                     "--threads" :  $.meta_info.threads,
                     "--chemistry" :  "10xv3",
-                    "--use-selective-alignment" : false, # only if using salmon alevin as theunderlying mapper
-                    # piscem options
-                    "--use-piscem" : $.meta_info.use_piscem,
                     "--struct-constraints" : false,
                     "--ignore-ambig-hits" : false,
                     "--no-poison" : false,
@@ -225,10 +218,9 @@ local template = {
                     "--sparse" : false,
                     "--keep-duplicates" : false,
                     "--threads" : $.meta_info.threads,
-                    "--use-piscem" : $.meta_info.use_piscem, 
-                    "--overwrite" : $.meta_info.use_piscem,
+                    "--overwrite" : false,
                     "--kmer-length" :  7,
-                    "--minimizer-length" : utils.ml($.meta_info.use_piscem, std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
+                    "--minimizer-length" : utils.ml(std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
                     "--decoy-paths" : null, # only if using piscem >= 0.7
                 },
 
@@ -276,7 +268,6 @@ local template = {
                     "--resolution" :  "cr-like",
                     "--expected-ori" :  "fw",
                     "--threads" :  $.meta_info.threads,
-                    "--use-piscem" : $.meta_info.use_piscem,
                     "--chemistry" :  "1{b[16]u[12]}2{r[15]}",
                 },
 

--- a/protocols/cite-seq-ADT_10xv3/cite-seq-ADT_10xv3.jsonnet
+++ b/protocols/cite-seq-ADT_10xv3/cite-seq-ADT_10xv3.jsonnet
@@ -116,8 +116,8 @@ local template = {
                     "--sparse" : false,
 				    "--gff3-fomrat" : false,
                     "--threads" : $.meta_info.threads,
-                    "--overwrite" : false,
-                    "--work-dir" : $.meta_info.output + "/gene_expression/simpleaf_index/workdir",
+                    "--overwrite" : true,
+                    "--work-dir" : null,
                     "--kmer-length" :  31,
                     "--minimizer-length" : utils.ml(std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
                     "--decoy-paths" : null, # only if using piscem >= 0.7
@@ -219,8 +219,8 @@ local template = {
                     "--sparse" : false,
                     "--keep-duplicates" : false,
                     "--threads" : $.meta_info.threads,
-                    "--overwrite" : false,
-                    "--work-dir" : $.meta_info.output + "/ADT/simpleaf_index/workdir",
+                    "--overwrite" : true,
+                    "--work-dir" : null,
                     "--kmer-length" :  7,
                     "--minimizer-length" : utils.ml(std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
                     "--decoy-paths" : null, # only if using piscem >= 0.7

--- a/protocols/simpleaf-index/simpleaf-index.jsonnet
+++ b/protocols/simpleaf-index/simpleaf-index.jsonnet
@@ -19,9 +19,6 @@ local meta_info = {
 	# number of threads for all commands
 	threads : 16, # change to other integer if needed # This defines `simpleaf index/quant --threads`
 
-	# boolean, true or false
-	use_piscem : false, # or use_piscem: false # This defines `simpleaf index/quant --use-piscem`
-
 	# Output directory.
 	output: output, # or output: "/path/to/output/dir" # this defines `simpleaf index/quant --output`
 };
@@ -91,10 +88,9 @@ local template = {
 				"--keep-duplicates" : false,
 				"--gff3-fomrat" : false,
 				"--threads" : $.meta_info.threads,
-				"--use-piscem" : $.meta_info.use_piscem, 
-				"--overwrite" : $.meta_info.use_piscem,
+				"--overwrite" : false,
 				"--kmer-length" :  31,
-				"--minimizer-length" : utils.ml($.meta_info.use_piscem, std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
+				"--minimizer-length" : utils.ml(std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
 				"--decoy-paths" : null, # only if using piscem >= 0.7
 			},
 

--- a/protocols/simpleaf-index/simpleaf-index.jsonnet
+++ b/protocols/simpleaf-index/simpleaf-index.jsonnet
@@ -89,6 +89,7 @@ local template = {
 				"--gff3-fomrat" : false,
 				"--threads" : $.meta_info.threads,
 				"--overwrite" : false,
+				"--work-dir" : $.meta_info.output + "/simpleaf_index/workdir",
 				"--kmer-length" :  31,
 				"--minimizer-length" : utils.ml(std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
 				"--decoy-paths" : null, # only if using piscem >= 0.7

--- a/protocols/simpleaf-index/simpleaf-index.jsonnet
+++ b/protocols/simpleaf-index/simpleaf-index.jsonnet
@@ -88,8 +88,8 @@ local template = {
 				"--keep-duplicates" : false,
 				"--gff3-fomrat" : false,
 				"--threads" : $.meta_info.threads,
-				"--overwrite" : false,
-				"--work-dir" : $.meta_info.output + "/simpleaf_index/workdir",
+				"--overwrite" : true,
+				"--work-dir" : null,
 				"--kmer-length" :  31,
 				"--minimizer-length" : utils.ml(std.get(self, "--kmer-length")), # a quick way to calculate minimizer length
 				"--decoy-paths" : null, # only if using piscem >= 0.7

--- a/utils/simpleaf_workflow_utils.libsonnet
+++ b/utils/simpleaf_workflow_utils.libsonnet
@@ -688,6 +688,18 @@
                                     ]:
                                         local given_kmer_length = $.get(field, "--kmer-length", use_default=true, default=31);
                                         std.toString(std.ceil(std.parseInt(given_kmer_length)/1.8)+1)
+                                    ,
+                                    // auto-inject --work-dir for simpleaf index if not provided
+                                    [if program_name == "simpleaf index" && std.objectHas(program_args, "--work-dir") then "--work-dir"]:
+                                        local given_work_dir = $.get(field, "--work-dir", use_default=true);
+                                        if given_work_dir != null then
+                                            given_work_dir
+                                        else
+                                            local given_output = $.get(field, "--output", use_default=true);
+                                            if given_output != null then
+                                                given_output + "/workdir"
+                                            else
+                                                output + "/" + field_name + "/workdir"
                                 })
                             else
                                 field
@@ -778,7 +790,8 @@
             '--overwrite': null,
             '--ref-type': null,
             '--minimizer-length': null,
-            '--keep-duplicates': null
+            '--keep-duplicates': null,
+            '--work-dir': null
         },
         'simpleaf quant': {
             // This is used for deciding by which order the commands are run

--- a/utils/simpleaf_workflow_utils.libsonnet
+++ b/utils/simpleaf_workflow_utils.libsonnet
@@ -689,17 +689,6 @@
                                         local given_kmer_length = $.get(field, "--kmer-length", use_default=true, default=31);
                                         std.toString(std.ceil(std.parseInt(given_kmer_length)/1.8)+1)
                                     ,
-                                    // auto-inject --work-dir for simpleaf index if not provided
-                                    [if program_name == "simpleaf index" && std.objectHas(program_args, "--work-dir") then "--work-dir"]:
-                                        local given_work_dir = $.get(field, "--work-dir", use_default=true);
-                                        if given_work_dir != null then
-                                            given_work_dir
-                                        else
-                                            local given_output = $.get(field, "--output", use_default=true);
-                                            if given_output != null then
-                                                given_output + "/workdir"
-                                            else
-                                                output + "/" + field_name + "/workdir"
                                 })
                             else
                                 field

--- a/utils/simpleaf_workflow_utils.libsonnet
+++ b/utils/simpleaf_workflow_utils.libsonnet
@@ -227,11 +227,8 @@
             error "Cannot get fields from a value: '%s'. " % o
     ,
     
-    ml(use_piscem,klen) :: 
-        if use_piscem then
-            std.ceil(klen / 1.8) + 1
-        else
-            null
+    ml(klen) ::
+        std.ceil(klen / 1.8) + 1
     ,
 
 
@@ -650,7 +647,7 @@
             }
     ),
 
-    add_meta_args_sub(o, threads, use_piscem, output, name)::
+    add_meta_args_sub(o, threads, output, name)::
     {
             local field = $.get(o, field_name),
             [field_name]:
@@ -681,49 +678,21 @@
                                             output + "/" + field_name
                                     ,
 
-                                    // // TODO: abundon this chunk when piscem bug is fixed
-                                    // // currently piscem has an bug: it will fail if setting custom kmer length.
-                                    // // So, here I check if --kmer-length flag is set. 
-                                    // // If it is set, then no piscem. Otherwise, we can call piscem if asked
-                                    // // If this bug is fixed, then we can turn to the logics implmented below
                                     [
-                                        if std.objectHas(program_args, "--use-piscem") && use_piscem then 
-                                            "--use-piscem"
-                                    ]: ""
-                                    ,
-                                    [
-                                        if program_name == "simpleaf index" &&
-                                            use_piscem 
-                                        then
-                                            "--overwrite"
-                                    ]: "",
-
-                                    // TODO: ask Julio if we have some simple formula to set minimizer length according to kmer length 
-                                    // In piscem, minimizer length must be smaller than kmer length
-                                    // however, salmon doesn't use minimizer, so it doesn't have this restriction
-                                    // As we want to switch between salmon and piscem, when using piscem, we have to manually set minimizer length 
-                                    // if the kmer-length is no larger than the default minimizer length (19).
-                                    [
-                                    // get kmer and minimizer length from workflow 
                                     local given_kmer_length = $.get(field, "--kmer-length", use_default=true);
                                     local given_minimizer_length = $.get(field, "--minimizer-length", use_default=true);
-                                    
-                                    // set the criteria
-                                    if program_name == "simpleaf index" && use_piscem then
+                                    if program_name == "simpleaf index" then
                                         if given_kmer_length != null && given_minimizer_length == null then
-                                            // default minimizer-length is 19, make sure the provided kmer-length is greater than that
                                             if std.parseInt(given_kmer_length) < 20 then
                                                 "--minimizer-length"
                                     ]:
-                                        // the same var defined above cannot be recognized in this scope
                                         local given_kmer_length = $.get(field, "--kmer-length", use_default=true, default=31);
-                                        // 1.8 is used here because by using this, passing 31 here will get 19
                                         std.toString(std.ceil(std.parseInt(given_kmer_length)/1.8)+1)
                                 })
                             else
                                 field
                     else
-                        $.add_meta_args_sub(field, threads, use_piscem, "%s/%s" % [output, field_name], name + field_name + " -> ")
+                        $.add_meta_args_sub(field, threads, "%s/%s" % [output, field_name], name + field_name + " -> ")
                 else
                     field
         for field_name in std.objectFields(o)
@@ -734,9 +703,7 @@
         local output = $.get_output(o);
         local mi = $.get(o, "meta_info", use_default=true);
         local threads = $.get(mi, "threads", use_default=true);
-        local use_piscem = $.get(mi, "use-piscem", use_default=true, default = false);
-
-        $.add_meta_args_sub(o, threads, use_piscem, output, "") + 
+        $.add_meta_args_sub(o, threads, output, "") +
             {meta_info+: {output: output}}
     ,
 
@@ -809,7 +776,6 @@
             '--sparse': null,
             '--kmer-length': null,
             '--overwrite': null,
-            '--use-piscem': null,
             '--ref-type': null,
             '--minimizer-length': null,
             '--keep-duplicates': null
@@ -842,8 +808,6 @@
             '--index': null,
             '--reads1': null,
             '--reads2': null,
-            '--use-piscem': null,
-            '--use-selective-alignment': null,
             '--map-dir': null
         },
     }


### PR DESCRIPTION
## Summary
- **Self-host barcode translation file**: The `3M-february-2018.txt.gz` barcode translation file URL pointed to `10XGenomics/cellranger` repo (`master` branch), which has been restructured — the URL no longer works. This PR hosts the file under `resources/` in this repo so feature barcode workflows are self-contained and immune to upstream URL changes.
- **Fix README doc links**: Updated links to match current simpleaf documentation structure (`workflow-command.html` → `workflow.html`, `get-workflow-config-command.html` → `workflow-get.html`, added `workflow-run.html`).
- **Fix typo**: "infomration" → "information" in README.

## Files changed
| File | Change |
|------|--------|
| `README.md` | Updated doc links, fixed typo |
| `protocols/10x-feature-barcode-crispr/*.jsonnet` | Barcode translation URL → self-hosted |
| `protocols/10x-feature-barcode-antibody/*.jsonnet` | Barcode translation URL → self-hosted |
| `protocols/10x-feature-barcode-antibody+crispr/*.jsonnet` | Barcode translation URL → self-hosted |
| `resources/translation_3M-february-2018.txt.gz` | New — self-hosted copy of the barcode translation file |

## Test plan
- [ ] Verify `resources/translation_3M-february-2018.txt.gz` is accessible via the new raw URL
- [ ] Run a feature barcode workflow (CRISPR or antibody) end-to-end to confirm barcode translation works with the new URL
- [ ] Verify README links resolve to valid simpleaf docs pages